### PR TITLE
Added includeScript option and test fixes

### DIFF
--- a/grails-app/services/com/megatome/grails/RecaptchaService.groovy
+++ b/grails-app/services/com/megatome/grails/RecaptchaService.groovy
@@ -67,6 +67,7 @@ class RecaptchaService {
                     publicKey: config.publicKey,
                     privateKey: config.privateKey,
                     includeNoScript: safeGetConfigValue('includeNoScript', true),
+                    includeScript: safeGetConfigValue('includeScript', true),
                     proxy: proxy)
         }
         recap

--- a/scripts/RecaptchaQuickstart.groovy
+++ b/scripts/RecaptchaQuickstart.groovy
@@ -64,6 +64,9 @@ recaptcha {
     // Include the noscript tags in the generated captcha
     includeNoScript = true
 
+    //Include the script tags in the generated captcha
+    includeScript = true
+
     // Set to false to disable the display of captcha
     enabled = true
 }

--- a/src/groovy/com/megatome/grails/recaptcha/ReCaptcha.groovy
+++ b/src/groovy/com/megatome/grails/recaptcha/ReCaptcha.groovy
@@ -31,6 +31,7 @@ public class ReCaptcha {
     String publicKey
     String privateKey
     Boolean includeNoScript = false
+    Boolean includeScript = true
 
     AuthenticatorProxy proxy = null
 
@@ -38,7 +39,7 @@ public class ReCaptcha {
      * Creates HTML output with embedded recaptcha. The string response should be output on a HTML page (eg. inside a JSP).
      *
      * @param errorMessage An errormessage to display in the captcha, null if none.
-     * @param options Options for rendering, <code>tabindex</code> and <code>theme</code> are currently supported by recaptcha. You can
+     * @param options Options for rendering, <code>theme</code>, <code>lang</code>, and <code>type</code> are currently supported by recaptcha. You can
      *   put any options here though, and they will be added to the RecaptchaOptions javascript array.
      * @return
      */
@@ -49,7 +50,10 @@ public class ReCaptcha {
         }
 
         def message = new StringBuffer()
-        message << "<script src=\"${JS_URL}?${qs.toString()}\" async defer></script>"
+
+        if (includeScript) {
+            message << "<script src=\"${JS_URL}?${qs.toString()}\" async defer></script>"
+        }
         message << "<div class=\"g-recaptcha\" data-sitekey=\"${publicKey}\""
         if (options?.theme) {
             message << " data-theme=\"${options.theme}\""
@@ -82,7 +86,9 @@ public class ReCaptcha {
 
         def message = new StringBuffer()
 
-        message <<  "<script type=\"text/javascript\" src=\"${recaptchaServer + AJAX_JS}\"></script>\r\n"
+        if (includeScript) {
+            message <<  "<script type=\"text/javascript\" src=\"${recaptchaServer + AJAX_JS}\"></script>\r\n"
+        }
 
         message << "<script type=\"text/javascript\">\r\nfunction showRecaptcha(element){Recaptcha.create(\"${publicKey}\", element, {" +
                 options.collect { "$it.key:'${it.value}'" }.join(', ') + "});}\r\n</script>\r\n"
@@ -135,7 +141,6 @@ public class ReCaptcha {
         if (!responseObject) {
             return false
         }
-
-        responseObject.success
+        responseObject.success?.trim()?.toBoolean() == true
     }
 }


### PR DESCRIPTION
Added an includeScript flag for the configuration recaptcha { .. } block
which, if false, does not output script tags to the response (similar to
includeNoScript).  It defaults to true to maintain backwards
compatibility.

Also, this commit fixes broken unit test cases and updates them for the
v2.0 API. Also added a test for the new flag.