### PR TITLE
update read timeout value from 1000 millis to 5000 millis

### DIFF
--- a/src/groovy/com/megatome/grails/recaptcha/net/Post.groovy
+++ b/src/groovy/com/megatome/grails/recaptcha/net/Post.groovy
@@ -32,9 +32,9 @@ public class Post {
         options.each { k,v -> if (this.hasProperty(k)) { this."$k" = v} }
         if (null == rest) {
             if (proxy?.isConfigured()) {
-                rest = new RestBuilder(connectTimeout: 10000, readTimeout: 1000, proxy: proxy.proxy)
+                rest = new RestBuilder(connectTimeout: 10000, readTimeout: 5000, proxy: proxy.proxy)
             } else {
-                rest = new RestBuilder(connectTimeout: 10000, readTimeout: 1000)
+                rest = new RestBuilder(connectTimeout: 10000, readTimeout: 5000)
             }
         }
     }


### PR DESCRIPTION
We have been having issues in production for a few of our Grails applications, where we are getting read timeouts on the call to verify the CAPTCHA answer with Google. Locally, we have increased the read timeout to 5 seconds, and this problem has disappeared.
